### PR TITLE
fix: wrong default keymap of evil-tex-bind-to-delim-map and a typo in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -182,7 +182,7 @@ figures:
 Same for ~evil-tex-bind-to-cdlatex-accents-map~ and ~evil-tex-bind-to-delim-map~
 #+BEGIN_SRC emacs-lisp
 (evil-tex-bind-to-cdlatex-accents-map '(("b" . "fbox")))
-(evil-tex-bind-to-delim-keymap '(("h" "\\huge(" . "\\huge)")))
+(evil-tex-bind-to-delim-map '(("h" "\\huge(" . "\\huge)")))
 #+END_SRC
 Same for ~evil-tex-user-delim-map-generator-alist~. For the complete format take
 a look at the documentation of ~evil-tex-bind-to-env-map~.

--- a/evil-tex.el
+++ b/evil-tex.el
@@ -1101,7 +1101,7 @@ Bind to `evil-tex-delim-map', or to KEYMAP if given.
 Format is identical to `evil-tex-bind-to-env-map', see that for
 explaination."
   (evil-tex--populate-surround-keymap
-   (or keymap evil-tex-cdlatex-accents-map)
+   (or keymap evil-tex-delim-map)
    key-generator-alist
    evil-tex--delim-function-prefix
    #'identity))


### PR DESCRIPTION
- As indicated by its documation, the function `evil-tex-bind-to-delim-map` is supposed to bind `key-generator-alist` to `evil-tex-delim-map` without specifying a keymap. However, the default keymap used by the function is `evil-tex-cdlatex-accents-map` in fact, which is corrected in the first commit.
- The second commit just fixes a typo of the readme. The function `evil-tex-bind-to-delim-map` is mistakely referred to as `evil-tex-bind-to-delim-keymap`.